### PR TITLE
Add support for KernelSU

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/SplashActivity.java
+++ b/app/src/main/java/com/drdisagree/iconify/SplashActivity.java
@@ -40,7 +40,7 @@ public class SplashActivity extends AppCompatActivity {
             keepShowing = false;
             intent = new Intent(SplashActivity.this, HomePage.class);
         } else {
-            if (RootUtil.isDeviceRooted() && RootUtil.isMagiskInstalled() && ModuleUtil.moduleExists() && OverlayUtil.overlayExists() && (BuildConfig.VERSION_CODE == Prefs.getInt(VER_CODE))) {
+            if (RootUtil.isDeviceRooted() && (RootUtil.isMagiskInstalled() || RootUtil.isKSUInstalled()) && ModuleUtil.moduleExists() && OverlayUtil.overlayExists() && (BuildConfig.VERSION_CODE == Prefs.getInt(VER_CODE))) {
                 keepShowing = false;
                 intent = new Intent(SplashActivity.this, HomePage.class);
             } else {

--- a/app/src/main/java/com/drdisagree/iconify/ui/activities/LandingPage3.java
+++ b/app/src/main/java/com/drdisagree/iconify/ui/activities/LandingPage3.java
@@ -36,7 +36,7 @@ import com.drdisagree.iconify.utils.SystemUtil;
 import com.drdisagree.iconify.utils.compiler.OverlayCompiler;
 import com.drdisagree.iconify.utils.helpers.BackupRestore;
 import com.topjohnwu.superuser.Shell;
-
+import org.zeroturnaround.zip.ZipUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
@@ -94,7 +94,7 @@ public class LandingPage3 extends AppCompatActivity {
         install_module.setOnClickListener(v -> {
             hasErroredOut = false;
             if (RootUtil.isDeviceRooted()) {
-                if (RootUtil.isMagiskInstalled()) {
+                if (RootUtil.isMagiskInstalled() || RootUtil.isKSUInstalled()) {
                     if (!Environment.isExternalStorageManager()) {
                         showInfo(R.string.need_storage_perm_title, R.string.need_storage_perm_desc);
 
@@ -339,6 +339,14 @@ public class LandingPage3 extends AppCompatActivity {
                 RootUtil.setPermissionsRecursively(644, Resources.OVERLAY_DIR + '/');
             }
 
+            if (!RootUtil.isMagiskInstalled()) {
+                Shell.cmd("cp -r /data/adb/modules/Iconify " + Resources.TEMP_DIR).exec();
+                Shell.cmd("rm -rf /data/adb/modules/Iconify").exec();
+                ZipUtil.pack(new File(Resources.TEMP_DIR + "/Iconify"), new File(Resources.TEMP_DIR + "/Iconify.zip"));
+                Shell.cmd("/data/adb/ksud module install " + Resources.TEMP_DIR + "/Iconify.zip").exec();
+               
+            }
+            
             logger = "Cleaning temporary directories";
             publishProgress(step);
             // Clean temp directory

--- a/app/src/main/java/com/drdisagree/iconify/utils/RootUtil.java
+++ b/app/src/main/java/com/drdisagree/iconify/utils/RootUtil.java
@@ -14,6 +14,10 @@ public class RootUtil {
         return Shell.cmd("[ -d /data/adb/magisk ]").exec().isSuccess();
     }
 
+    public static boolean isKSUInstalled() {
+        return Shell.cmd("[ -d /data/adb/ksu ]").exec().isSuccess();
+    }
+    
     public static void setPermissions(final int permission, final String filename) {
         Shell.cmd("chmod " + permission + ' ' + filename).exec();
     }

--- a/app/src/main/java/com/drdisagree/iconify/utils/RootUtil.java
+++ b/app/src/main/java/com/drdisagree/iconify/utils/RootUtil.java
@@ -11,11 +11,11 @@ public class RootUtil {
     }
 
     public static boolean isMagiskInstalled() {
-        return Shell.cmd("[ -d /data/adb/magisk ]").exec().isSuccess();
+        return Shell.cmd("magisk -v").exec().isSuccess();
     }
 
     public static boolean isKSUInstalled() {
-        return Shell.cmd("[ -d /data/adb/ksu ]").exec().isSuccess();
+        return Shell.cmd("/data/adb/ksud -h").exec().isSuccess();
     }
     
     public static void setPermissions(final int permission, final String filename) {


### PR DESCRIPTION
- It'll proceed only if either magisk or ksu is found.
- Allow the normal module installation to happen .
- After that if ksu exists create a module zip, remove data/adb/modules/Iconify and flash the module automatically through cli(no user interection required) else in case of magisk proceed nomally.

Tested with KernelSU version 10672 and Manager version 10677. Everything including the xposed customizations are working.