### PR TITLE
WeatherWork: return null location when using custom location

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/weather/WeatherWork.kt
+++ b/app/src/main/java/com/drdisagree/iconify/weather/WeatherWork.kt
@@ -127,6 +127,8 @@ class WeatherWork(val mContext: Context, workerParams: WorkerParameters) :
     @get:SuppressLint("MissingPermission")
     private val currentLocation: Location?
         get() {
+            if (isCustomLocation(mContext)) return null
+
             val lm = mContext.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
             if (!doCheckLocationEnabled()) {


### PR DESCRIPTION
Directly skip getCurrentLocation if custom location enabled