### PR TITLE
module: skip global mounting routine on MAGIC_MOUNT variant

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/common/Const.kt
+++ b/app/src/main/java/com/drdisagree/iconify/common/Const.kt
@@ -119,6 +119,10 @@ object Const {
             modid="Iconify"
             SUSFS_BIN=/data/adb/ksu/bin/ksu_susfs
             
+            if [ ${'$'}KSU_MAGIC_MOUNT = true ]; then
+            	exit 0
+            fi
+
             [ ! -f ${'$'}MODDIR/skip_mount ] && touch ${'$'}MODDIR/skip_mount
             
             [ -w /mnt ] && basefolder=/mnt


### PR DESCRIPTION
https://github.com/5ec1cff/KernelSU/commit/ea7e293ff25531488e0c9a3437d85a522bd933a7

this is not needed to magic mount variant of kernelsu as it works exactly like magisk.