### PR TITLE
fix: OnePlus QS header tile color not applied on init

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/OpQsHeader.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/OpQsHeader.kt
@@ -1425,29 +1425,45 @@ class OpQsHeader(context: Context) : ModPack(context) {
     }
 
     private fun updateInternetTileColors() {
+        // Retry init if colors not yet initialized (QSTileViewImpl not constructed yet)
+        if (colorActive == null || colorInactive == null) {
+            try {
+                initResources()
+            } catch (_: Throwable) {
+            }
+        }
+
         if (mInternetEnabled) {
             mOpQsHeaderView?.setInternetTileColor(
-                tileColor = colorActive,
-                labelColor = colorLabelActive
+                tileColor = colorActive ?: return,
+                labelColor = colorLabelActive ?: Color.WHITE
             )
         } else {
             mOpQsHeaderView?.setInternetTileColor(
-                tileColor = colorInactive,
-                labelColor = colorLabelInactive
+                tileColor = colorInactive ?: return,
+                labelColor = colorLabelInactive ?: Color.WHITE
             )
         }
     }
 
     private fun updateBluetoothTileColors() {
+        // Retry init if colors not yet initialized (QSTileViewImpl not constructed yet)
+        if (colorActive == null || colorInactive == null) {
+            try {
+                initResources()
+            } catch (_: Throwable) {
+            }
+        }
+
         if (mBluetoothEnabled) {
             mOpQsHeaderView?.setBluetoothTileColor(
-                tileColor = colorActive,
-                labelColor = colorLabelActive
+                tileColor = colorActive ?: return,
+                labelColor = colorLabelActive ?: Color.WHITE
             )
         } else {
             mOpQsHeaderView?.setBluetoothTileColor(
-                tileColor = colorInactive,
-                labelColor = colorLabelInactive
+                tileColor = colorInactive ?: return,
+                labelColor = colorLabelInactive ?: Color.WHITE
             )
         }
     }


### PR DESCRIPTION
The Internet/Bluetooth tiles in the OnePlus QS header sometimes show up in the Material You accent color (purple on most setups) instead of the correct color. Tapping the tile fixes it.

This happens because tileLayoutClass's constructor can fire updateInternetTileColors() before QSTileViewImpl has been constructed. At that point colorActive is still null, so setInternetTileColor(null, null) just returns and leaves the tile at whatever the system default is.

Now retries initResources() if colors are null, and bails out early if they're still not available. The tile picks up the right color on the next state change.

Verified on Xperia 5 V (XQ-DE44, Android 15).