### PR TITLE
feat: add horizontal QS tile layout option

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/data/common/Preferences.kt
+++ b/app/src/main/java/com/drdisagree/iconify/data/common/Preferences.kt
@@ -58,6 +58,7 @@ object Preferences {
     const val CHIP_STATUS_ICONS_RADIUS_BOTTOM_RIGHT = "xposed_chipstatusiconsradiusbottomright"
     const val CHIP_STATUS_ICONS_RADIUS_BOTTOM_LEFT = "xposed_chipstatusiconsradiusbottomleft"
     const val VERTICAL_QSTILE_SWITCH = "xposed_verticalqstile"
+    const val HORIZONTAL_QSTILE_SWITCH = "xposed_horizontalqstile"
     const val HIDE_QSLABEL_SWITCH = "xposed_hideqslabel"
     const val VOLUME_PANEL_PERCENTAGE = "xposed_volumepanelpercentage"
     const val VOLUME_PANEL_SAFETY_WARNING = "xposed_volumepanelsafetywarning"

--- a/app/src/main/java/com/drdisagree/iconify/ui/fragments/xposed/QuickSettings.kt
+++ b/app/src/main/java/com/drdisagree/iconify/ui/fragments/xposed/QuickSettings.kt
@@ -1,5 +1,6 @@
 package com.drdisagree.iconify.ui.fragments.xposed
 
+import android.os.Bundle
 import com.drdisagree.iconify.R
 import com.drdisagree.iconify.data.common.Preferences.COLORED_NOTIFICATION_ALTERNATIVE_SWITCH
 import com.drdisagree.iconify.data.common.Preferences.COLORED_NOTIFICATION_ICON_SWITCH
@@ -11,13 +12,18 @@ import com.drdisagree.iconify.data.common.Preferences.FIX_QS_TILE_COLOR
 import com.drdisagree.iconify.data.common.Preferences.HIDE_QSLABEL_SWITCH
 import com.drdisagree.iconify.data.common.Preferences.HIDE_QS_SILENT_TEXT
 import com.drdisagree.iconify.data.common.Preferences.HIDE_STATUS_ICONS_SWITCH
+import com.drdisagree.iconify.data.common.Preferences.HORIZONTAL_QSTILE_SWITCH
 import com.drdisagree.iconify.data.common.Preferences.QSPANEL_HIDE_CARRIER
 import com.drdisagree.iconify.data.common.Preferences.SELECTED_QS_TEXT_COLOR
 import com.drdisagree.iconify.data.common.Preferences.VERTICAL_QSTILE_SWITCH
 import com.drdisagree.iconify.ui.activities.MainActivity
 import com.drdisagree.iconify.ui.base.ControlledPreferenceFragmentCompat
+import com.drdisagree.iconify.ui.preferences.SwitchPreference
 
 class QuickSettings : ControlledPreferenceFragmentCompat() {
+
+    private var verticalPref: SwitchPreference? = null
+    private var horizontalPref: SwitchPreference? = null
 
     override val title: String
         get() = getString(R.string.activity_title_quick_settings)
@@ -31,11 +37,35 @@ class QuickSettings : ControlledPreferenceFragmentCompat() {
     override val hasMenu: Boolean
         get() = true
 
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        super.onCreatePreferences(savedInstanceState, rootKey)
+
+        verticalPref = findPreference(VERTICAL_QSTILE_SWITCH)
+        horizontalPref = findPreference(HORIZONTAL_QSTILE_SWITCH)
+
+        updateMutualExclusion()
+    }
+
+    private fun updateMutualExclusion() {
+        verticalPref?.let { v ->
+            horizontalPref?.let { h ->
+                h.isEnabled = !v.isChecked
+                v.isEnabled = !h.isChecked
+            }
+        }
+    }
+
     override fun updateScreen(key: String?) {
         super.updateScreen(key)
 
         when (key) {
             VERTICAL_QSTILE_SWITCH,
+            HORIZONTAL_QSTILE_SWITCH -> updateMutualExclusion()
+        }
+
+        when (key) {
+            VERTICAL_QSTILE_SWITCH,
+            HORIZONTAL_QSTILE_SWITCH,
             CUSTOM_QS_TEXT_COLOR,
             SELECTED_QS_TEXT_COLOR,
             HIDE_QSLABEL_SWITCH,

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/QuickSettings.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/QuickSettings.kt
@@ -40,6 +40,7 @@ import com.drdisagree.iconify.data.common.Preferences.QQS_TOPMARGIN_PORTRAIT
 import com.drdisagree.iconify.data.common.Preferences.QS_TOPMARGIN_LANDSCAPE
 import com.drdisagree.iconify.data.common.Preferences.QS_TOPMARGIN_PORTRAIT
 import com.drdisagree.iconify.data.common.Preferences.SELECTED_QS_TEXT_COLOR
+import com.drdisagree.iconify.data.common.Preferences.HORIZONTAL_QSTILE_SWITCH
 import com.drdisagree.iconify.data.common.Preferences.VERTICAL_QSTILE_SWITCH
 import com.drdisagree.iconify.xposed.ModPack
 import com.drdisagree.iconify.xposed.modules.extras.utils.DisplayUtils.isLandscape
@@ -88,6 +89,7 @@ class QuickSettings(context: Context) : ModPack(context) {
     private var mKeyguardStateController: Any? = null
     private val isAtLeastAndroid14 = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
     private var isVerticalQSTileActive = false
+    private var isHorizontalQSTileActive = false
     private var isHideLabelActive = false
     private var customQsMarginsEnabled = false
     private var qsTilePrimaryTextSize: Float? = null
@@ -98,6 +100,7 @@ class QuickSettings(context: Context) : ModPack(context) {
     override fun updatePrefs(vararg key: String) {
         Xprefs.apply {
             isVerticalQSTileActive = getBoolean(VERTICAL_QSTILE_SWITCH, false)
+            isHorizontalQSTileActive = getBoolean(HORIZONTAL_QSTILE_SWITCH, false)
             isHideLabelActive = getBoolean(HIDE_QSLABEL_SWITCH, false)
             customQsMarginsEnabled = getBoolean(CUSTOM_QS_MARGIN, false)
             qqsTopMarginPort = getSliderInt(QQS_TOPMARGIN_PORTRAIT, 100)
@@ -126,6 +129,7 @@ class QuickSettings(context: Context) : ModPack(context) {
     override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
         initQsAccentColor()
         setVerticalTiles()
+        setHorizontalTiles()
         setQsMargin()
         fixQsTileAndLabelColorA14()
         fixNotificationColorA14()
@@ -226,6 +230,76 @@ class QuickSettings(context: Context) : ModPack(context) {
                 if (!isVerticalQSTileActive) return@runAfter
 
                 fixTileLayout(param.thisObject as LinearLayout, mParam)
+            }
+    }
+
+    private fun setHorizontalTiles() {
+        val qsTileViewImplClass = findClass("$SYSTEMUI_PACKAGE.qs.tileimpl.QSTileViewImpl")
+
+        qsTileViewImplClass
+            .hookConstructor()
+            .runAfter { param ->
+                if (!isHorizontalQSTileActive || isVerticalQSTileActive) return@runAfter
+
+                try {
+                    val tile = param.thisObject as LinearLayout
+
+                    tile.orientation = LinearLayout.HORIZONTAL
+                    tile.gravity = Gravity.CENTER_VERTICAL or Gravity.START
+
+                    val labelContainer = param.thisObject.getField(
+                        "labelContainer"
+                    ) as LinearLayout
+
+                    labelContainer.layoutParams = LinearLayout.LayoutParams(
+                        0,
+                        LinearLayout.LayoutParams.WRAP_CONTENT,
+                        1f
+                    ).apply {
+                        marginStart = mContext.toPx(8)
+                    }
+
+                    (param.thisObject.getField(
+                        "label"
+                    ) as TextView).apply {
+                        textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                    }
+
+                    (param.thisObject.getField(
+                        "secondaryLabel"
+                    ) as TextView).apply {
+                        textAlignment = View.TEXT_ALIGNMENT_VIEW_START
+                    }
+
+                    (param.thisObject.getField("sideView") as View).visibility = View.GONE
+                } catch (throwable: Throwable) {
+                    log(this@QuickSettings, throwable)
+                }
+            }
+
+        qsTileViewImplClass
+            .hookMethod("onConfigurationChanged")
+            .runAfter { param ->
+                if (!isHorizontalQSTileActive || isVerticalQSTileActive) return@runAfter
+
+                try {
+                    val tile = param.thisObject as LinearLayout
+
+                    tile.orientation = LinearLayout.HORIZONTAL
+                    tile.gravity = Gravity.CENTER_VERTICAL or Gravity.START
+
+                    val labelContainer = param.thisObject.getField(
+                        "labelContainer"
+                    ) as LinearLayout
+
+                    (labelContainer.layoutParams as LinearLayout.LayoutParams).apply {
+                        width = 0
+                        weight = 1f
+                        marginStart = mContext.toPx(8)
+                    }
+                } catch (throwable: Throwable) {
+                    log(this@QuickSettings, throwable)
+                }
             }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -602,6 +602,8 @@
     <string name="section_title_qs_tile">QS Tile</string>
     <string name="vertical_qs_tile_title">Vertical QS Tile</string>
     <string name="vertical_qs_tile_desc">Show label below QS icon</string>
+    <string name="horizontal_qs_tile_title">Horizontal QS Tile</string>
+    <string name="horizontal_qs_tile_desc">Show label beside QS icon (recommended with 2 columns)</string>
     <string name="hide_qs_tile_label_title">Hide QS Tile Label</string>
     <string name="hide_qs_tile_label_desc">Use only with vertical tiles</string>
     <string name="qs_tile_label_scaling_title">Text Size Scaling</string>

--- a/app/src/main/res/xml/xposed_quick_settings.xml
+++ b/app/src/main/res/xml/xposed_quick_settings.xml
@@ -57,6 +57,13 @@
             android:title="@string/hide_qs_tile_label_title"
             app:iconSpaceReserved="false" />
 
+        <com.drdisagree.iconify.ui.preferences.SwitchPreference
+            android:key="xposed_horizontalqstile"
+            android:summary="@string/horizontal_qs_tile_desc"
+            android:title="@string/horizontal_qs_tile_title"
+            app:iconSpaceReserved="false" />
+
+
     </com.drdisagree.iconify.ui.preferences.PreferenceCategory>
 
     <com.drdisagree.iconify.ui.preferences.PreferenceCategory


### PR DESCRIPTION
Adds a "Horizontal QS Tile" toggle that sets QSTileViewImpl to HORIZONTAL orientation with the label container filling the space beside the icon (width=0, weight=1). Handy for 2-column setups where vertical tiles waste a lot of space.

Mutually exclusive with the existing vertical tile toggle — enabling one grays out the other.

Verified on Xperia 5 V (XQ-DE44, Android 15).