### PR TITLE
feat: Sony/Xperia device compatibility

### DIFF
--- a/app/src/foss/java/com/drdisagree/iconify/xposed/modules/lockscreen/depthwallpaper/DepthWallpaperA15.kt
+++ b/app/src/foss/java/com/drdisagree/iconify/xposed/modules/lockscreen/depthwallpaper/DepthWallpaperA15.kt
@@ -28,7 +28,7 @@ import com.drdisagree.iconify.R
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_FAILURE
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_SUBJECT
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_SUCCESS
-import com.drdisagree.iconify.data.common.Const.ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY
+import com.drdisagree.iconify.xposed.modules.lockscreen.AlbumArt.Companion.addAlbumArtVisibilityListener
 import com.drdisagree.iconify.data.common.Const.AI_PLUGIN_PACKAGE
 import com.drdisagree.iconify.data.common.Const.SYSTEMUI_PACKAGE
 import com.drdisagree.iconify.data.common.Preferences.CUSTOM_DEPTH_WALLPAPER_SWITCH
@@ -58,6 +58,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethod
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.log
 import com.drdisagree.iconify.xposed.modules.lockscreen.AlbumArt.Companion.shouldShowAlbumArt
 import com.drdisagree.iconify.xposed.modules.lockscreen.Lockscreen.Companion.isComposeLockscreen
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
@@ -103,14 +104,7 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
     )
 
     private var shouldShowForeground = true
-    private var mBroadcastRegistered = false
-    private val mReceiver: BroadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY) {
-                updateForegroundVisibility()
-            }
-        }
-    }
+    private var mAlbumArtListenerRegistered = false
 
     override fun updatePrefs(vararg key: String) {
         Xprefs.apply {
@@ -145,26 +139,12 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag", "NewApi")
     override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
-        // Receiver to handle foreground visibility
-        if (!mBroadcastRegistered) {
-            val intentFilter = IntentFilter().apply {
-                addAction(ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY)
+        // Listen for album art visibility changes directly (in-process)
+        if (!mAlbumArtListenerRegistered) {
+            addAlbumArtVisibilityListener {
+                updateForegroundVisibility()
             }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                mContext.registerReceiver(
-                    mReceiver,
-                    intentFilter,
-                    Context.RECEIVER_EXPORTED
-                )
-            } else {
-                mContext.registerReceiver(
-                    mReceiver,
-                    intentFilter
-                )
-            }
-
-            mBroadcastRegistered = true
+            mAlbumArtListenerRegistered = true
         }
 
         mPluginReceiver = object : BroadcastReceiver() {
@@ -266,6 +246,11 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
                             )
                         ) {
                             entryV.removeOnAttachStateChangeListener(this)
+                            return@postDelayed
+                        }
+
+                        // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                        if (OemUtils.isSony && rootView.clipChildren) {
                             return@postDelayed
                         }
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/Lockscreen.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/Lockscreen.kt
@@ -26,6 +26,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.callMethodSile
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookConstructor
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookLayout
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethod
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
@@ -136,6 +137,11 @@ class Lockscreen(context: Context) : ModPack(context) {
                                 )
                             ) {
                                 entryV.removeOnAttachStateChangeListener(this)
+                                return@postDelayed
+                            }
+
+                            // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                            if (OemUtils.isSony && rootView.clipChildren) {
                                 return@postDelayed
                             }
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/clock/LockscreenClockA15.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/clock/LockscreenClockA15.kt
@@ -85,6 +85,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.log
 import com.drdisagree.iconify.xposed.modules.extras.views.AodBurnInProtection
 import com.drdisagree.iconify.xposed.modules.extras.views.ArcProgressImageView
 import com.drdisagree.iconify.xposed.modules.lockscreen.Lockscreen.Companion.isComposeLockscreen
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import com.drdisagree.iconify.xposed.utils.XPrefs.XprefsIsInitialized
 import de.robv.android.xposed.XC_MethodHook
@@ -267,6 +268,11 @@ class LockscreenClockA15(context: Context) : ModPack(context) {
                             )
                         ) {
                             entryV.removeOnAttachStateChangeListener(this)
+                            return@postDelayed
+                        }
+
+                        // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                        if (OemUtils.isSony && rootView.clipChildren) {
                             return@postDelayed
                         }
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/weather/LockscreenWeatherA15.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/weather/LockscreenWeatherA15.kt
@@ -58,6 +58,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethod
 import com.drdisagree.iconify.xposed.modules.extras.views.AodBurnInProtection
 import com.drdisagree.iconify.xposed.modules.extras.views.CurrentWeatherView
 import com.drdisagree.iconify.xposed.modules.lockscreen.Lockscreen.Companion.isComposeLockscreen
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import com.drdisagree.iconify.xposed.utils.XPrefs.XprefsIsInitialized
 import de.robv.android.xposed.XC_MethodHook
@@ -223,6 +224,11 @@ class LockscreenWeatherA15(context: Context) : ModPack(context) {
                             )
                         ) {
                             entryV.removeOnAttachStateChangeListener(this)
+                            return@postDelayed
+                        }
+
+                        // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                        if (OemUtils.isSony && rootView.clipChildren) {
                             return@postDelayed
                         }
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/widgets/LockscreenWidgetsA15.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/lockscreen/widgets/LockscreenWidgetsA15.kt
@@ -64,6 +64,7 @@ import com.drdisagree.iconify.xposed.modules.extras.views.LockscreenWidgetsView
 import com.drdisagree.iconify.xposed.modules.lockscreen.Lockscreen.Companion.isComposeLockscreen
 import com.drdisagree.iconify.xposed.modules.lockscreen.widgets.LockscreenWidgets.Companion.launchableImageViewClass
 import com.drdisagree.iconify.xposed.modules.lockscreen.widgets.LockscreenWidgets.Companion.launchableLinearLayoutClass
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import com.drdisagree.iconify.xposed.utils.XPrefs.XprefsIsInitialized
 import de.robv.android.xposed.XC_MethodHook
@@ -298,6 +299,11 @@ class LockscreenWidgetsA15(context: Context) : ModPack(context) {
                             )
                         ) {
                             entryV.removeOnAttachStateChangeListener(this)
+                            return@postDelayed
+                        }
+
+                        // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                        if (OemUtils.isSony && rootView.clipChildren) {
                             return@postDelayed
                         }
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/themes/QSLightThemeA15.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/themes/QSLightThemeA15.kt
@@ -30,6 +30,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethod
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethodMatchPattern
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.log
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.setField
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.SystemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import de.robv.android.xposed.XC_MethodHook
@@ -953,6 +954,11 @@ class QSLightThemeA15(context: Context) : ModPack(context) {
         isDark = isCurrentlyDark
 
         calculateColors()
+
+        // Sony devices don't support QSLT/QSDT framework overlays due to
+        // different QS resource structures. The Xposed hooks in calculateColors()
+        // handle theming instead.
+        if (OemUtils.isSony) return
 
         Utils.disableOverlays(qsLightThemeOverlay, qsDualToneOverlay)
 

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/themes/Utils.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/themes/Utils.kt
@@ -3,6 +3,7 @@ package com.drdisagree.iconify.xposed.modules.quicksettings.themes
 import android.service.quicksettings.Tile
 import com.drdisagree.iconify.xposed.HookEntry.Companion.enqueueProxyCommand
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.getField
+import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.log
 import de.robv.android.xposed.XC_MethodHook
 
 object Utils {
@@ -43,15 +44,23 @@ object Utils {
 
     fun enableOverlay(pkgName: String) {
         enqueueProxyCommand { proxy ->
-            proxy.runCommand("cmd overlay enable --user current $pkgName")
-            proxy.runCommand("cmd overlay set-priority $pkgName highest")
+            try {
+                proxy.runCommand("cmd overlay enable --user current $pkgName")
+                proxy.runCommand("cmd overlay set-priority $pkgName highest")
+            } catch (e: Throwable) {
+                log("QSThemeUtils", "Failed to enable overlay $pkgName: ${e.message}")
+            }
         }
     }
 
     fun enableOverlay(pkgName: String, priority: String) {
         enqueueProxyCommand { proxy ->
-            proxy.runCommand("cmd overlay enable --user current $pkgName")
-            proxy.runCommand("cmd overlay set-priority $pkgName $priority")
+            try {
+                proxy.runCommand("cmd overlay enable --user current $pkgName")
+                proxy.runCommand("cmd overlay set-priority $pkgName $priority")
+            } catch (e: Throwable) {
+                log("QSThemeUtils", "Failed to enable overlay $pkgName: ${e.message}")
+            }
         }
     }
 
@@ -64,13 +73,21 @@ object Utils {
         }
 
         enqueueProxyCommand { proxy ->
-            proxy.runCommand(command.toString().trim { it <= ' ' })
+            try {
+                proxy.runCommand(command.toString().trim { it <= ' ' })
+            } catch (e: Throwable) {
+                log("QSThemeUtils", "Failed to enable overlays: ${e.message}")
+            }
         }
     }
 
     fun disableOverlay(pkgName: String) {
         enqueueProxyCommand { proxy ->
-            proxy.runCommand("cmd overlay disable --user current $pkgName")
+            try {
+                proxy.runCommand("cmd overlay disable --user current $pkgName")
+            } catch (e: Throwable) {
+                log("QSThemeUtils", "Failed to disable overlay $pkgName: ${e.message}")
+            }
         }
     }
 
@@ -82,7 +99,11 @@ object Utils {
         }
 
         enqueueProxyCommand { proxy ->
-            proxy.runCommand(command.toString().trim { it <= ' ' })
+            try {
+                proxy.runCommand(command.toString().trim { it <= ' ' })
+            } catch (e: Throwable) {
+                log("QSThemeUtils", "Failed to disable overlays: ${e.message}")
+            }
         }
     }
 }

--- a/app/src/main/java/com/drdisagree/iconify/xposed/utils/OemUtils.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/utils/OemUtils.kt
@@ -1,0 +1,9 @@
+package com.drdisagree.iconify.xposed.utils
+
+import android.os.Build
+
+object OemUtils {
+    val isSony: Boolean by lazy {
+        Build.MANUFACTURER.equals("Sony", ignoreCase = true)
+    }
+}

--- a/app/src/standard/java/com/drdisagree/iconify/xposed/modules/lockscreen/depthwallpaper/DepthWallpaperA15.kt
+++ b/app/src/standard/java/com/drdisagree/iconify/xposed/modules/lockscreen/depthwallpaper/DepthWallpaperA15.kt
@@ -29,7 +29,7 @@ import com.drdisagree.iconify.R
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_FAILURE
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_SUBJECT
 import com.drdisagree.iconify.data.common.Const.ACTION_EXTRACT_SUCCESS
-import com.drdisagree.iconify.data.common.Const.ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY
+import com.drdisagree.iconify.xposed.modules.lockscreen.AlbumArt.Companion.addAlbumArtVisibilityListener
 import com.drdisagree.iconify.data.common.Const.AI_PLUGIN_PACKAGE
 import com.drdisagree.iconify.data.common.Const.SYSTEMUI_PACKAGE
 import com.drdisagree.iconify.data.common.Preferences.CUSTOM_DEPTH_WALLPAPER_SWITCH
@@ -60,6 +60,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.hookMethod
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.log
 import com.drdisagree.iconify.xposed.modules.lockscreen.AlbumArt.Companion.shouldShowAlbumArt
 import com.drdisagree.iconify.xposed.modules.lockscreen.Lockscreen.Companion.isComposeLockscreen
+import com.drdisagree.iconify.xposed.utils.OemUtils
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
 import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
@@ -105,14 +106,7 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
     )
 
     private var shouldShowForeground = true
-    private var mBroadcastRegistered = false
-    private val mReceiver: BroadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context?, intent: Intent?) {
-            if (intent?.action == ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY) {
-                updateForegroundVisibility()
-            }
-        }
-    }
+    private var mAlbumArtListenerRegistered = false
 
     override fun updatePrefs(vararg key: String) {
         Xprefs.apply {
@@ -147,26 +141,12 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag", "NewApi")
     override fun handleLoadPackage(loadPackageParam: LoadPackageParam) {
-        // Receiver to handle foreground visibility
-        if (!mBroadcastRegistered) {
-            val intentFilter = IntentFilter().apply {
-                addAction(ACTION_UPDATE_DEPTH_WALLPAPER_FOREGROUND_VISIBILITY)
+        // Listen for album art visibility changes directly (in-process)
+        if (!mAlbumArtListenerRegistered) {
+            addAlbumArtVisibilityListener {
+                updateForegroundVisibility()
             }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                mContext.registerReceiver(
-                    mReceiver,
-                    intentFilter,
-                    Context.RECEIVER_EXPORTED
-                )
-            } else {
-                mContext.registerReceiver(
-                    mReceiver,
-                    intentFilter
-                )
-            }
-
-            mBroadcastRegistered = true
+            mAlbumArtListenerRegistered = true
         }
 
         mPluginReceiver = object : BroadcastReceiver() {
@@ -268,6 +248,11 @@ class DepthWallpaperA15(context: Context) : ModPack(context) {
                             )
                         ) {
                             entryV.removeOnAttachStateChangeListener(this)
+                            return@postDelayed
+                        }
+
+                        // Sony has duplicate keyguard_root_view; the correct one has clipChildren=false
+                        if (OemUtils.isSony && rootView.clipChildren) {
                             return@postDelayed
                         }
 


### PR DESCRIPTION
Tested on Xperia 5 V (XQ-DE44, Android 15). Xperia's SystemUI is close to AOSP so most hooks work out of the box, but a few things needed fixing.

Sony's super_notification_shade.xml has two KeyguardRootView with the same id (keyguard_root_view). The one we want has clipChildren="false", the other doesn't. All lockscreen modules (clock, widgets, weather, depth wallpaper, lock icon) now check for this on Sony and skip the wrong one. The listener stays attached so the correct view still gets picked up.

QSLT/QSDT overlays fail on Sony because their framework doesn't have the same QS resource structure as AOSP. Since calculateColors() already handles the theming through Xposed hooks, the overlay enable/disable calls are just skipped on Sony.

Also wrapped all overlay operations in Utils.kt with try-catch — not Sony-specific, just good practice since these were silently failing before.

Everything is behind OemUtils.isSony (Build.MANUFACTURER == "Sony"), no effect on other devices.