### PR TITLE
[Android 17] Add toggle for disabling motion springs and animations on quick tiles

### DIFF
--- a/app/src/main/java/com/drdisagree/iconify/data/keys/XposedKey.kt
+++ b/app/src/main/java/com/drdisagree/iconify/data/keys/XposedKey.kt
@@ -102,6 +102,7 @@ enum class XposedKey(override val default: Any?) : Key {
     COMPACT_MEDIA_PLAYER(false),
     BLUR_MEDIA_PLAYER_ARTWORK(false),
     BLUR_MEDIA_PLAYER_ARTWORK_RADIUS(60f),
+    DISABLE_QS_EXPRESSIVE_EFFECTS(false),
     HIDE_QS_SILENT_TEXT(false),
     HIDE_QS_FOOTER_BUTTONS(false),
     QS_PANEL_HIDE_CARRIER(false),

--- a/app/src/main/java/com/drdisagree/iconify/features/xposed/quicksettings/main/screens/QuickSettingsScreen.kt
+++ b/app/src/main/java/com/drdisagree/iconify/features/xposed/quicksettings/main/screens/QuickSettingsScreen.kt
@@ -165,6 +165,12 @@ val quickSettingsPreferences = preferenceScreen {
 
     category(title = stringRes(R.string.section_title_qs_elements)) {
         switch(
+            key = XposedKey.DISABLE_QS_EXPRESSIVE_EFFECTS,
+            title = stringRes(R.string.disable_qs_expressive_effects_title),
+            summary = { stringRes(R.string.disable_qs_expressive_effects_desc) },
+        )
+
+        switch(
             key = XposedKey.HIDE_QS_SILENT_TEXT,
             title = stringRes(R.string.hide_qs_silent_text_title),
             summary = { stringRes(R.string.hide_qs_silent_text_desc) },
@@ -222,6 +228,7 @@ fun QuickSettingsScreen(
             XposedKey.NOTIFICATION_HEADS_UP_BLUR.name,
             XposedKey.COMPACT_MEDIA_PLAYER.name,
             XposedKey.BLUR_MEDIA_PLAYER_ARTWORK.name,
+            XposedKey.DISABLE_QS_EXPRESSIVE_EFFECTS.name,
             XposedKey.HIDE_QS_SILENT_TEXT.name,
             XposedKey.HIDE_QS_FOOTER_BUTTONS.name,
             XposedKey.QS_PANEL_HIDE_CARRIER.name,

--- a/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/QuickSettings.kt
+++ b/app/src/main/java/com/drdisagree/iconify/xposed/modules/quicksettings/QuickSettings.kt
@@ -36,6 +36,7 @@ import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.setExtraField
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.setField
 import com.drdisagree.iconify.xposed.modules.extras.utils.toolkit.setFieldSilently
 import com.drdisagree.iconify.xposed.utils.XPrefs.Xprefs
+import de.robv.android.xposed.XC_MethodHook
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
 
 @SuppressLint("DiscouragedApi")
@@ -44,6 +45,7 @@ class QuickSettings(context: Context) : ModPack(context) {
     private var fixNotificationColor = true
     private var fixNotificationFooterButtonsColor = true
     private var fixNotificationExpandButtonColor = true
+    private var disableExpressiveEffects = false
     private var hideSilentText = false
     private var hideFooterButtons = false
     private var qqsTopMarginPort = 100
@@ -68,6 +70,7 @@ class QuickSettings(context: Context) : ModPack(context) {
                 getBoolean(XposedKey.FIX_NOTIFICATION_FOOTER_BUTTON_COLOR)
             fixNotificationExpandButtonColor =
                 getBoolean(XposedKey.FIX_NOTIFICATION_EXPAND_BUTTON_COLOR)
+            disableExpressiveEffects = getBoolean(XposedKey.DISABLE_QS_EXPRESSIVE_EFFECTS)
             hideSilentText = getBoolean(XposedKey.HIDE_QS_SILENT_TEXT)
             hideFooterButtons = getBoolean(XposedKey.HIDE_QS_FOOTER_BUTTONS)
             compactMediaPlayerEnabled = getBoolean(XposedKey.COMPACT_MEDIA_PLAYER)
@@ -84,6 +87,43 @@ class QuickSettings(context: Context) : ModPack(context) {
         manageQsElementVisibility()
         compactMediaPlayer()
         blurMediaPlayerArtwork()
+        setQsExpressiveness()
+    }
+
+    private fun setQsExpressiveness() {
+        val inTileBounceableLambda = ThreadLocal<Boolean>()
+        inTileBounceableLambda.set(false)
+
+        val tileBounceableLambdaClass = findClass("$SYSTEMUI_PACKAGE.qs.panels.ui.compose.infinitegrid.TileKt\$\$ExternalSyntheticLambda2")
+        tileBounceableLambdaClass.hookMethod("invoke").runBefore {
+                if (!disableExpressiveEffects) return@runBefore
+                inTileBounceableLambda.set(true)
+            }.runAfter {
+                inTileBounceableLambda.set(false)
+            }
+
+        val bounceableClass =
+            findClass("com.android.compose.animation.BounceableKt")
+        bounceableClass.hookMethod($$"bounceable$default")
+            .runAfter { param ->
+                if (!inTileBounceableLambda.get()!!) return@runAfter
+                param.result = param.args[0]
+            }
+
+        val tileDefaultsClass = findClass("$SYSTEMUI_PACKAGE.qs.panels.ui.compose.infinitegrid.TileDefaults")
+        tileDefaultsClass.hookMethod("animateTileShapeAsState")
+            .run(object : XC_MethodHook() {
+                private val prevState = ThreadLocal<Int>()
+
+                override fun beforeHookedMethod(param: MethodHookParam) {
+                    prevState.set(param.args[0].getFieldSilently("visualState") as? Int ?: return)
+                    param.args[0].setFieldSilently("visualState", 1 /* STATE_INACTIVE */)
+                }
+
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    param.args[0].setFieldSilently("visualState", prevState.get() ?: return)
+                }
+            })
     }
 
     private fun setQsMargin() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -659,6 +659,8 @@
     <string name="hide_qs_on_lockscreen_desc">Disable quick settings panel on secured lockscreen</string>
     <string name="hide_qs_on_lockscreen_a15_title">Disable QS on Lockscreen</string>
     <string name="hide_qs_on_lockscreen_a15_desc">Disable quick settings tiles on secured lockscreen</string>
+    <string name="disable_qs_expressive_effects_title">Disable Expressive Effects</string>
+    <string name="disable_qs_expressive_effects_desc">Disables the rounding and bounce effects when a tile is pressed</string>
     <string name="hide_qs_silent_text_title">Hide Silent Text</string>
     <string name="hide_qs_silent_text_desc">Hide silent text shown as header of silent notifications</string>
     <string name="hide_qs_footer_buttons_title">Hide Footer Buttons</string>


### PR DESCRIPTION
(Warning: intended for Android 17. As I understand it, currently Iconify targets Android 16 until further notice, so this PR may be pushed back until this is updated.)

Adds a toggle within the quick settings section. When turned on, tiles will no longer bounce when toggled, and will not change shape.